### PR TITLE
removed deprecated selectors

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,7 +1,7 @@
 @import "ui-variables";
 @import "ui-mixins";
 
-atom-text-editor[mini], atom-text-editor[mini]::shadow {
+atom-text-editor[mini], atom-text-editor[mini] {
   color: @text-color-highlight;
   background-color: @input-background-color;
   border: 1px solid @input-border-color;
@@ -13,13 +13,13 @@ atom-text-editor[mini], atom-text-editor[mini]::shadow {
   .selection .region { background-color: lighten(@input-background-color, 10%); }
 }
 
-atom-text-editor[mini].is-focused, atom-text-editor[mini].is-focused::shadow {
+atom-text-editor[mini].is-focused, atom-text-editor[mini].is-focused {
   background-color: lighten(@input-background-color, 5%);
   .selection .region { background-color: desaturate(@background-color-info, 50%); }
 }
 
 // FIXME: these should go in syntax themes?
-atom-text-editor, atom-text-editor::shadow {
+atom-text-editor, atom-text-editor {
   .gutter.drop-shadow {
     -webkit-box-shadow: -2px 0 10px 2px #222;
   }

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,7 +1,7 @@
 @import "ui-variables";
 @import "ui-mixins";
 
-atom-text-editor[mini], atom-text-editor[mini] {
+atom-text-editor[mini], atom-text-editor[mini].editor {
   color: @text-color-highlight;
   background-color: @input-background-color;
   border: 1px solid @input-border-color;
@@ -13,13 +13,13 @@ atom-text-editor[mini], atom-text-editor[mini] {
   .selection .region { background-color: lighten(@input-background-color, 10%); }
 }
 
-atom-text-editor[mini].is-focused, atom-text-editor[mini].is-focused {
+atom-text-editor[mini].is-focused, atom-text-editor[mini].is-focused.editor {
   background-color: lighten(@input-background-color, 5%);
   .selection .region { background-color: desaturate(@background-color-info, 50%); }
 }
 
 // FIXME: these should go in syntax themes?
-atom-text-editor, atom-text-editor {
+atom-text-editor, atom-text-editor.editor {
   .gutter.drop-shadow {
     -webkit-box-shadow: -2px 0 10px 2px #222;
   }


### PR DESCRIPTION
got a message from atom saying that the pseudo-selectors ":host" and "::shadow" are deprecated, so i've removed them to get rid of the message. looks like it's working